### PR TITLE
Swedish: add missing strings, fix mistakes, general language improvement

### DIFF
--- a/swedish.inc
+++ b/swedish.inc
@@ -1,83 +1,81 @@
 <?php
 
 # language dependent text used in the interface for users (not admin)
-# translation by Björn Pålsson <bjorn@pm-net.se>
-# translated for version 2.10.4
+# translation for version 2.10.4 by Björn Pålsson <bjorn@pm-net.se>
+# updated for version 3.0.10 by Anders Jensen-Urstad <anders@unix.se>
 
 $strCharSet             = 'UTF-8';
+$strLancode             = 'sv'; ## two letter iso code
+$strLandir              = 'ltr'; ## language direction (ltr or rtl)
 $strName                = 'Namn';
 $strAddress             = 'Adress';
 $strEmail               = 'E-postadress';
-$strEmailrep		   = 'Repetera adress'; 
 $strTown                = 'Ort';
 $strPostcode            = 'Postnummer';
-$strSubscribeInfo       = 'Anmäl dig till en eller flera av våra listor genom att fylla i formuläret nedan.';
-$strRequired            = 'Oligatoriskt fält';
-$strSubscribeTitle      = 'Anmäl dig till en av våra listor';
-$strPleaseSelect        = 'Välj de listor du önskar att anmäla dig till';
-$strSubmit              = 'Anmäl till de valda listorna';
-$strNotAvailable        = 'Beklagar, det finns inga listor tillgängliga';
-$strEnterName           = 'Skriv in ditt namn';
-$strEnterEmail          = 'Skriv in din E-post adress';
-$strInvalidHostInEmail  = 'Sorry, email to that domain is undeliverable, please check that you typed the correct email address';
-$strEnterList           = 'Välj en lista du önskar att anmäla dig till';
-$strThanks              = 'Tack för att du har anmält dig till en av våra listor.';
-$strEmailConfirmation   = 'Du kommer snart att få ett E-brev med en bekräftelse på de listor du anmält dig till';
-$strEnterList           = 'Please select a newsletter to subscribe to';
-$strPleaseEnter         = 'Vänligen skriv in din';
+$strSubscribeInfo       = '<h3>Prenumerera på våra nyhetsbrev</h3>';
+$strRequired            = 'Obligatoriskt fält';
+$strSubscribeTitle      = 'Prenumerera på ett av våra nyhetsbrev';
+$strPleaseSelect        = 'Välj de nyhetsbrev du vill anmäla dig till';
+$strSubmit              = 'Prenumerera på de valda nyhetsbreven';
+$strNotAvailable        = 'Beklagar, det finns inga nyhetsbrev tillgängliga';
+$strEnterName           = 'Ange ditt namn';
+$strEnterEmail          = 'Ange din e-postadress';
+$strConfirmEmail        = 'Bekräfta din e-postadress';
+$strInvalidHostInEmail  = 'E-post till den domänen är ej levererbar. Var god kontrollera att du skrev rätt adress.';
+$strEnterList           = 'Välj ett nyhetsbrev du önskar att anmäla dig till';
+$strPleaseEnter         = 'Var god ange';
 # the thanks message can contain placeholders
 #$strThanks              = 'Dear [FIRST NAME], <br/>Thank you for subscribing to our lists.';
-$strThanks              = 'Tack för ditt intresse för våra nyhetsbrev.';
+$strThanks              = 'Tack för att du anmält dig till våra nyhetsbrev.';
 # the EmailConfirmation message can contain placeholders
-$strEmailConfirmation   = 'Your email [email] has been added to our system. You will be e-mailed shortly with confirmation of the lists you have subscribed to.';
-#$strEmailConfirmation   = 'Your email has been added to our system. You will be e-mailed shortly with a request to confirm your membership. Please make sure to click the link in that message to confirm your subscription.';
-$strEmailFailed          = 'Sorry, sending the email to request your confirmation failed, please click "Reload" to try again. If it still does not work, it may be because you are listed on our "Black List", which means that you cannot receive emails from our newsletter system. In that case, please contact the administrator.';
-$strUnsubscribeTitle    = 'Avanmäl dig från en av våra listor';
-$strUnsubscribeDone     = 'Du är avanmäld från de valda listorna. Du kommer att få en bekräftelse inom kort.';
+#$strEmailConfirmation   = 'Your email [email] has been added to our system. You will be e-mailed shortly with confirmation of the lists you have subscribed to.';
+$strEmailConfirmation   = 'Din e-postadress har lagts till i vårt system. Du kommer att få ett e-postmeddelande med en förfrågan om att bekräfta ditt medlemskap. Klicka på länken i det meddelandet för att bekräfta din prenumeration.';
+$strEmailFailed          = 'Det gick inte att skicka meddelandet för att be om din bekräftelse. Var god klicka på "Ladda om" för att försöka igen. Kontakta administratören om det fortfarande inte fungerar.';
+$strUnsubscribeTitle    = 'Avanmäl dig från våra nyhetsbrev';
+$strUnsubscribeDone     = 'Du är avanmäld från de valda nyhetsbreven. Du kommer att få en bekräftelse inom kort.';
 $strBack                = 'Tillbaka';
-$strUnsubscribeInfo     = 'Avanmäl dig från en eller flera av våra listor';
+$strUnsubscribeInfo     = 'Avanmäl dig från en eller flera av våra nyhetsbrev';
 $strContinue            = 'Fortsätt';
-$strUnsubscribeSelect   = 'Välj de listor du önskar att avanmäla dig från';
-$strAllLists            = 'Alla listor';
+$strUnsubscribeSelect   = 'Välj de nyhetsbrev du vill avanmäla dig från';
+$strAllLists            = 'Alla nyhetsbrev';
 $strNoLists             = 'Ingen av dem';
-$strNoListsFound        = 'Beklagar, du är inte anmäld till några av våra listor med den E-postadressen';
-$strUnsubscribeRequestForReason = 'We are sorry to find you are not any longer interested in our newsletter. To help us improve our services, we would be grateful if you could tell us why:';
-$strUnsubscribeFinalInfo = '<br/><b>Please note</b>: this page is to stop receiving emails from our newsletter system <b>forever</b>. If you want to change your email, or if you want to change which newsletters you receive, please <a href="[PREFERENCESURL]">update your preferences</a> instead';
-$strResubmit            = 'Skicka E-brev igen';
-$strUnsubscribeSubmit   = 'Avanmäl de valda listorna';
+$strUnsubscribeRequestForReason = 'Vi beklagar att du inte längre är intresserad av vårt nyhetsbrev. För att hjälpa oss förbättra våra tjänster så vore vi tacksamma om du kunde berätta varför:';
+$strUnsubscribeFinalInfo = '<br/><b>Observera</b>: den här sidan är till för att sluta ta emot e-postmeddelanden från vårt nyhetsbrevssystem <b>för evigt</b>. Om du vill ändra din e-postadress, eller om du vill ändra vilka nyhetsbrev du får, var god <a href="[PREFERENCESURL]">uppdatera dina inställningar</a> i stället';
+$strNoListsFound        = 'Beklagar, du är inte anmäld till något av våra nyhetsbrev med den e-postadressen';
+$strResubmit            = 'Skicka igen';
+$strUnsubscribeSubmit   = 'Avanmäl från de valda nyhetsbreven';
 $strValuesMissing       = 'De följande obligatoriska fälten saknas';
-$strConfirmInfo                 = 'Tack för bekräftelsen på anmälan till våra listor.<br />De listor du har anmält dig till visas nedan:';
-$strConfirmTitle                = 'Bekräftelse på anmälan till nyhetsbrev';
-$strUserNotFound        = 'Användare finns inte';
+$strConfirmInfo         = 'Tack för bekräftelsen på anmälan till våra nyhetsbrev. De nyhetsbrev du har anmält dig till visas nedan:';
+$strConfirmTitle        = 'phpLists sida för medlemskapsbekräftelse';
+$strUserNotFound        = 'Användare hittades ej';
 $strUserAlreadyInitialised = 'Beklagar, ditt lösenord är redan satt';
-$strConfirmFailInfo     = 'Sorry, your request for confirmation was not recognised. Please make sure to use the full web address as mentioned in the email that you received. Sometimes this web address wraps onto multiple lines.';
-$strPreferHTMLEmail     = 'Jag föredrar att få mina E-brev i HTML-format';
-$strPreferTextEmail     = 'Jag föredrar att få mina E-brev i Textformat';
-$strPreferredFormat      = 'Jag vill ha mina E-brev i:';
-$strText                 = 'Text';
+$strConfirmFailInfo     = 'Din förfrågan om bekräftelse kändes inte igen. Var god se till att du använder hela adressen som nämndes i e-postmeddelandet du fick. Ibland kan denna adress brytas till flera rader.';
+$strPreferHTMLEmail     = 'Jag föredrar att få mina e-postmeddelanden i HTML-format';
+$strPreferTextEmail     = 'Jag föredrar att få mina e-postmeddelanden i textformat';
+$strPreferredFormat     = 'Jag vill ha mina e-postmeddelanden i:';
+$strText                = 'Text';
 $strHTML                = 'HTML';
 $strPreferencesTitle    = 'Uppdatera dina inställningar';
-$strPreferencesInfo     = 'Vänligen bekräfta att uppgifterna nedan är korrekta och klicka på "Spara".';
-$strUpdatePreferences   = 'Spara';
-$strPreferencesEmailChanged = 'Your email has changed. Please visit the link in the email you will receive to confirm your new email address';
-$strYouAreBlacklisted = 'Your email is listed in our "Black List", which means that you have requested us never to send you any more newsletters. <br/>
-In order to receive emails again, manual intervention is required by our administrator. Please contact us stating explicitly that you want to receive newsletters again, and we will
-take you off our black list. ';
+$strPreferencesInfo     = 'Vänligen bekräfta att uppgifterna nedan är korrekta och klicka på knappen "Uppdatera".';
+$strUpdatePreferences   = 'Uppdatera';
+$strPreferencesEmailChanged = 'Din e-postadress har ändrats. Vänligen besök länken i e-postmeddelandet som du kommer att få för att bekräfta din nya e-postadress.';
+$strYouAreBlacklisted = 'Din e-postadress är i vår "svartlista", vilket innebär att du bett oss att aldrig skicka dig några nyhetsbrev igen. <br />
+För att få nyhetsbrev igen krävs manuellt ingripande av vår administratör. Var god kontakta oss och säg uttryckligen att du vill få nyhetsbrev igen.';
 $strPreferencesNotificationSent = 'Du kommer att få en bekräftelse på ändringarna';
-$strPreferencesUpdated = 'Tack för att du håller dina uppgifter uppdaterarde.';
+$strPreferencesUpdated = 'Tack. Vi har uppdaterat din information.';
 $strClickHere          = 'Klicka här';
-$strThisLink           = 'denna länken';
-$strToUnsubscribe      = 'Om du inte vill få fler nyhetsbrev skall du ';
-$strToUpdate           = 'För att uppdatera dina uppgifter går du till ';
-$strSendHTML           = 'Skicka HTML';
+$strThisLink           = 'denna länk';
+$strToUnsubscribe      = 'Om du inte vill få fler nyhetsbrev ska du ';
+$strToUpdate           = 'För att uppdatera dina uppgifter och för att avprenumerera, besök';
+$strSendHTML           = 'Skicka e-post i HTML-format';
 $strYes                = 'Ja';
 $strNo                 = 'Nej';
-$strUnsubscribe        = 'Avsluta';
+$strUnsubscribe        = 'Avsluta prenumeration';
 $strAllMailinglists    = 'Alla nyhetsbrev';
 $strAttachmentIntro     = 'Detta meddelande innehåller bilagor som kan visas i en webbläsare:';
 $strLocation           = 'Plats';
-$strFrequency           = 'Hur ofta skickar du meddelande';
-$strHourly             = 'Varje timma';
+$strFrequency           = 'Hur ofta skickar vi dig meddelanden';
+$strHourly             = 'Varje timme';
 $strDaily               = 'Dagligen';
 $strWeekly             = 'Veckovis';
 $strMonthly             = 'Månadsvis';
@@ -85,34 +83,52 @@ $strChoosePassword      = 'Välj ett lösenord';
 $strConfirmPassword    = 'Bekräfta lösenordet';
 $strEnterPassword       = 'Skriv in önskat lösenord';
 $strForgotPassword     = 'Glömt lösenord';
+$strforgotpasswordemailbody = '
+    kära nyhetsbrevsmästare
+
+    jag glömde mitt lösenord för phplist-nyhetsbrevssystemet.
+    kan du återställa det till något och berätta det nya lösenordet
+    för mig?
+
+    tack
+';
 $strPassword           = 'Lösenord';
 $strPassword2           = 'Bekräfta lösenord';
 $strPasswordsNoMatch    = 'Lösenorden är inte lika';
 $strEmailsNoMatch     = 'E-postadresserna är inte lika';
-$strInvalidPassword     = 'Fel: ogiltig E-postadress eller lösenord';
-$strPasswordSent        = 'Ditt lösenord skickas till dig i ett e-brev. Du kommer att få det inom några minuter.';
-$strPasswordRemindSubject = 'Ditt lösenord för vårt system';
+$strInvalidPassword     = 'Fel: ogiltig e-postadress eller lösenord';
+$strPasswordSent        = 'Ditt lösenord skickas till dig i ett e-postmeddelande. Du kommer att få det inom några minuter.';
+$strPasswordRemindSubject = 'Ditt lösenord för våra nyhetsbrev';
 $strPasswordRemindMessage = 'Ditt lösenord är ';
-$strPasswordRemindInfo = 'Skriv in din E-postadress och tryck "'.$strForgotPassword.'" för att får lösenordet skickat till dig.';
-$strLogin               = 'Login';
-$strLoginTitle          = 'Skriv in E-postadress och lösenord';
-$strLoginInfo           = 'Denna sidan kräver ett lösenord. '.$strLoginTitle;
-$strPersonalLocationInfo = '<p>Denna sida kräver en personlig identifikationssträng som man hittar i varje meddelande vi skickar.<br/>
-  Om du klickar på den länken och du trots det får detta meddelande skall du säkerställa att hela länken
-  följer med till adressfältet i din webbläsare. Ibland kan adressen brytas upp på flera rader.</p>
-  <p>Om du inte har denna adress kan du få ett meddelande tillsänt dig med länken.
-  Skriv in din E-postadress och tryck "Continue".';
-$strPersonalLocationSent = '<h1>Operationen lyckades! Du kommer att få ett meddelande med din personliga länk inom kort.</h1>';
-$strUserExists   = '<br/>En användare med den E-postadressen finns redan och inte med detta lösenordet';
-$strUserExistsExplanationStart = '<br/>För att få tillgång till ditt lösenord klickar du ';
+$strPasswordRemindInfo = 'Skriv in din e-postadress och klicka på knappen "'.$strForgotPassword.'" för att få lösenordet skickat till dig.';
+$strLogin               = 'Inloggning';
+$strLoginTitle          = 'Skriv in din e-postadress och ditt lösenord';
+$strLoginInfo           = 'Denna sidan kräver ett lösenord. Var god ange din e-postadress och ditt lösenord.';
+$strPersonalLocationInfo = '<p>Denna sida kräver en personlig identifikationssträng som du hittar i varje meddelande vi skickar till dig.</p>
+  <p>Om du klickar på den länken och du trots det får detta meddelande ska du försäkra dig om att hela länken följer med till adressfältet i din webbläsare. Ibland kan adressen brytas upp på flera rader.</p>
+  <p>Om du inte har denna adress kan du skriva in din e-postadress i rutan och klicka på "Fortsätt".</p>';
+$strPersonalLocationSent = '<h3>Du bör få ett meddelande med din personliga länk inom kort.</h3>';
+$strUserExists   = '<br/>En användare med den e-postadressen finns redan, och vårt system innehåller ett annorlunda lösenord';
+$strUserExistsExplanationStart = 'För att få tillgång till ditt lösenord klickar du ';
 $strUserExistsExplanationLink = 'här';
 $strUserExistsExplanationEnd = ' för att gå till sidan där du kan efterfråga din personliga länk';
+$strExplainBlacklist = 'E-postadressen som du anger här kommer att registreras i vår databas med enda syfte att blockera alla e-postmeddelanden som skickas från detta system.';
+
+$strUserExistsResubscribe = 'En användare med den adressen finns redan';
+$strUserExistsResubscribeExplanation = 'Besök <a href="%s">inställningssidan</a> för att uppdatera din information.';
+
+
 $strForwardTitle = 'Vidarebefordra ett meddelande till någon';
 $strForwardSubtitle = 'Vidarebefordrar meddelandet med ämnet ';
-$strForwardEnterEmail = 'Ange en giltig E-postadress att vidarebefordra till';
+$strForwardEnterEmail = 'Ange en giltig e-postadress att vidarebefordra till';
+$strForwardInvalidEmail = '%s är inte en giltig e-postadress';
+$strForwardBlacklistedEmail = 'Mottagaren har bett om att inte få några e-postmeddelanden från detta system.';
+$strForwardEnterEmails = 'Var god ange maximalt %s giltiga e-postadresser att vidarebefordra till i denna ruta, en per rad';
 $strForwardSuccessInfo ='Detta meddelande är vidarebefordrat';
-$strForwardFailInfo = 'Vidarebefordran fungerade inte';
-$strForwardAlreadyDone = 'Detta meddelande är redan vidarebefordrat till den E-postadressen';
+$strForwardFailInfo = 'Vidarebefordran misslyckades';
+$strForwardAlreadyDone = 'Detta meddelande är redan vidarebefordrat till den e-postadressen';
+$strForwardCountReached = 'Maximalt antal vidarebefordringar uppnått';
+$strForwardNoteLimitReached = 'Maximal längd för personlig anteckning nådd';
 $strForwardFooter = 'Detta meddelande är vidarebefordrat till dig av [FORWARDEDBY].
   Du är inte automatiskt anmäld till nyhetsbrevet.
   För att anmäla dig kan du gå till';


### PR DESCRIPTION
The Swedish translation had a whole bunch of missing and/or untranslated strings, some spelling mistakes and strange wording, etc. I compared it with 3.0.10's english.inc, line by line, and fixed all that (I think!). Should be pretty good now.
